### PR TITLE
fix: token decoding 문제 해결, extractId 메서드 추가

### DIFF
--- a/src/main/java/com/example/Sparta_Store/config/JwtUtil.java
+++ b/src/main/java/com/example/Sparta_Store/config/JwtUtil.java
@@ -33,6 +33,8 @@ public class JwtUtil {
     }
 
     private Claims extractAllClaims(String token) {
+        token = token.replace("Bearer ", ""); // 앞에 붙는 'Bearer ' 제거
+
         return Jwts.parser()
             .setSigningKey(key) // 비밀 키를 사용하여 서명 검증
             .parseClaimsJws(token)
@@ -55,6 +57,10 @@ public class JwtUtil {
                 .setIssuedAt(date) // 발급 시간 설정
                 .signWith(key, signatureAlgorithm) // 비밀 키와 알고리즘으로 서명
                 .compact(); // JWT 토큰 생성
+    }
+
+    public Long extractId(String token) {
+        return extractAllClaims(token).get("id", Long.class);
     }
 
     public String extractRoles(String token) {


### PR DESCRIPTION
`token = token.replace("Bearer ", ""); // 앞에 붙는 'Bearer ' 제거`
는 extract claim 과정에서 발생하는` DecodingException: Illegal base64url character: ' ' `에러를 해결하기 위해 추가했습니다.
다른 방법 아시면 공유해주세요.

![image](https://github.com/user-attachments/assets/b3595807-e908-499b-92f4-cb4d13414a5a)
