### PR TITLE
Feature/security

### DIFF
--- a/src/main/java/com/example/Sparta_Store/config/SecurityConfig.java
+++ b/src/main/java/com/example/Sparta_Store/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
             .addFilterBefore(jwtFilter, SecurityContextHolderAwareRequestFilter.class)
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/users/signUp", "/users/login", "/login", "/css/**", "/oauth2/**", "/auth/login", "/style.css").permitAll() // 회원가입, 로그인, CSS 파일 요청 허용
-                .requestMatchers(HttpMethod.GET, "/items", "/items/**").permitAll() // 아이템 조회 허용
+                .requestMatchers(HttpMethod.GET, "/items", "/items/**","/popularItems/**").permitAll() // 아이템 조회 허용
                 .requestMatchers("/admin/**").hasRole("ADMIN") //admin 이 붙은것은 ADMIN 이 존재해야만 통과 나머지는 누구나 가능하게 했습니다.
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/Sparta_Store/item/controller/ItemController.java
+++ b/src/main/java/com/example/Sparta_Store/item/controller/ItemController.java
@@ -2,16 +2,15 @@ package com.example.Sparta_Store.item.controller;
 
 import com.example.Sparta_Store.item.dto.request.ItemSearchRequestDto;
 import com.example.Sparta_Store.item.dto.response.ItemResponseDto;
+import com.example.Sparta_Store.item.dto.response.SelectItemResponseDto;
 import com.example.Sparta_Store.item.service.ItemService;
+import com.example.Sparta_Store.ranking.RedisRankingService;
 import com.example.Sparta_Store.util.PageQuery;
 import com.example.Sparta_Store.util.PageResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ItemController {
 
     private final ItemService itemService;
+    private final RedisRankingService redisRankingService;
 
     @GetMapping
     public ResponseEntity<PageResult<ItemResponseDto>> getItems(
@@ -36,5 +36,12 @@ public class ItemController {
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(itemService.getSearchItems(inStock, dto.keyword(), pageQuery));
+    }
+
+    @GetMapping("/select/{id}")
+    public ResponseEntity<SelectItemResponseDto> selectItem(@PathVariable Long id){
+        SelectItemResponseDto selectItemResponseDto = itemService.SelectItem(id);
+        redisRankingService.addToRedis(id);
+        return new ResponseEntity<>(selectItemResponseDto,HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/Sparta_Store/item/dto/response/SelectItemResponseDto.java
+++ b/src/main/java/com/example/Sparta_Store/item/dto/response/SelectItemResponseDto.java
@@ -1,0 +1,6 @@
+package com.example.Sparta_Store.item.dto.response;
+
+public record SelectItemResponseDto (
+        
+){
+}

--- a/src/main/java/com/example/Sparta_Store/item/dto/response/SelectItemResponseDto.java
+++ b/src/main/java/com/example/Sparta_Store/item/dto/response/SelectItemResponseDto.java
@@ -1,6 +1,21 @@
 package com.example.Sparta_Store.item.dto.response;
 
+import com.example.Sparta_Store.item.entity.Item;
+
 public record SelectItemResponseDto (
-        
+  String name,
+  String img_url,
+  String description,
+  int price,
+  int stock_quantity
 ){
+    public static SelectItemResponseDto from(Item item) {
+        return new SelectItemResponseDto(
+                item.getName(),
+                item.getImgUrl(),
+                item.getDescription(),
+                item.getPrice(),
+                item.getStockQuantity()
+        );
+    }
 }

--- a/src/main/java/com/example/Sparta_Store/item/service/ItemService.java
+++ b/src/main/java/com/example/Sparta_Store/item/service/ItemService.java
@@ -1,6 +1,7 @@
 package com.example.Sparta_Store.item.service;
 
 import com.example.Sparta_Store.item.dto.response.ItemResponseDto;
+import com.example.Sparta_Store.item.dto.response.SelectItemResponseDto;
 import com.example.Sparta_Store.item.entity.Item;
 import com.example.Sparta_Store.item.repository.ItemRepository;
 import com.example.Sparta_Store.orderItem.entity.OrderItem;
@@ -54,5 +55,12 @@ public class ItemService {
             Item item = lockWithItems.get(orderItem.getItem().getId());
             item.decreaseStock(orderItem.getQuantity());
         });
+    }
+
+    public SelectItemResponseDto SelectItem(Long id) {
+        Item item = itemRepository.findById(id)
+                .orElseThrow(()->new RuntimeException("해당아이템이 없습니다."));
+
+        return SelectItemResponseDto.from(item);
     }
 }

--- a/src/main/java/com/example/Sparta_Store/oAuth/jwt/JwtFilter.java
+++ b/src/main/java/com/example/Sparta_Store/oAuth/jwt/JwtFilter.java
@@ -45,7 +45,7 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        if(requestURI.contains("items") && request.getMethod().equals("GET")) {
+        if(requestURI.contains("items") || requestURI.contains("popularItems") && request.getMethod().equals("GET")) {
             filterChain.doFilter(request,response);
             return;
         }

--- a/src/main/java/com/example/Sparta_Store/popularItem/controller/PopularItemController.java
+++ b/src/main/java/com/example/Sparta_Store/popularItem/controller/PopularItemController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,5 +33,11 @@ public class PopularItemController {
         List<LikesDto> response = popularItemService.getMostPopularLikedItems();
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    // 카테고리별 검색순위
+    @GetMapping("/{category}")
+    public List<String> getScore(@PathVariable String category){
+        return popularItemService.getCategoryRanking(category);
     }
 }

--- a/src/main/java/com/example/Sparta_Store/ranking/RedisRankingRepository.java
+++ b/src/main/java/com/example/Sparta_Store/ranking/RedisRankingRepository.java
@@ -1,4 +1,15 @@
 package com.example.Sparta_Store.ranking;
 
-public class RedisRankingRepository {
+import com.example.Sparta_Store.item.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RedisRankingRepository extends JpaRepository<Item,Long> {
+
+    @Query("SELECT c.name FROM Item i JOIN i.category c WHERE i.id = :itemId")
+    String findCategoryNameByItemId(@Param("itemId") Long itemId);
+
+    @Query("SELECT i.name FROM Item i WHERE i.id = :itemId")
+    String findItemNameByItemId(@Param("itemId") Long itemId);
 }

--- a/src/main/java/com/example/Sparta_Store/ranking/RedisRankingRepository.java
+++ b/src/main/java/com/example/Sparta_Store/ranking/RedisRankingRepository.java
@@ -1,0 +1,4 @@
+package com.example.Sparta_Store.ranking;
+
+public class RedisRankingRepository {
+}

--- a/src/main/java/com/example/Sparta_Store/ranking/RedisRankingService.java
+++ b/src/main/java/com/example/Sparta_Store/ranking/RedisRankingService.java
@@ -1,0 +1,4 @@
+package com.example.Sparta_Store.ranking;
+
+public class RedisRankingService {
+}

--- a/src/main/java/com/example/Sparta_Store/ranking/RedisRankingService.java
+++ b/src/main/java/com/example/Sparta_Store/ranking/RedisRankingService.java
@@ -1,4 +1,57 @@
 package com.example.Sparta_Store.ranking;
 
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class RedisRankingService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisRankingRepository redisRankingRepository;
+    private final SortedSet<String> synchronizedSet = Collections.synchronizedSortedSet(new TreeSet<>());
+
+    public void addToRedis(Long itemId) {
+        // 아이템 ID를 통해 카테고리 값을 가져옴
+        String category = redisRankingRepository.findCategoryNameByItemId(itemId);
+
+        String itemName = redisRankingRepository.findItemNameByItemId(itemId);
+
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+
+        // Redis에 ZADD 명령어로 추가
+        Double currentScore = zSetOps.score(category, itemName);
+
+        if (currentScore == null) {
+            // 아이템이 없으면 아이템을 생성한다.
+            zSetOps.add(category, itemName, 1);
+        } else {
+            // 아이템이 있으면 점수를 증가시킨다
+            zSetOps.incrementScore(category, itemName, 1);
+        }
+    }
+
+    @Scheduled(cron = "0 0 0 * * Mon")
+    public void clearRedisCache() {
+        // 한주에 한번 모든 카테고리의 데이터를 초기화하는 로직
+
+        Set<String> categories = redisTemplate.keys("*"); // 모든 카테고리 키 가져오기
+        if (categories != null) {
+            for (String category : categories) {
+                redisTemplate.delete(category); // 카테고리 삭제
+            }
+        }
+        synchronizedSet.clear();
+    }
 }

--- a/src/test/java/com/example/Sparta_Store/rank/service/RedisRankingServiceTest.java
+++ b/src/test/java/com/example/Sparta_Store/rank/service/RedisRankingServiceTest.java
@@ -1,0 +1,74 @@
+package com.example.Sparta_Store.rank.service;
+
+import com.example.Sparta_Store.category.entity.Category;
+import com.example.Sparta_Store.ranking.RedisRankingRepository;
+import com.example.Sparta_Store.ranking.RedisRankingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+public class RedisRankingServiceTest {
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private RedisRankingRepository redisRankingRepository;
+
+    @InjectMocks
+    private RedisRankingService redisRankingService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testAddToRedis_NewItem() {
+        //given
+        Long itemId = 1L;
+        String categoryName = "Category1";
+        String itemName = "Item1";
+
+        when(redisRankingRepository.findCategoryNameByItemId(itemId)).thenReturn(categoryName);
+        when(redisRankingRepository.findItemNameByItemId(itemId)).thenReturn(itemName);
+
+        ZSetOperations<String, String> zSetOps = mock(ZSetOperations.class);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
+        when(zSetOps.score(categoryName, itemName)).thenReturn(null);
+
+        //when
+        redisRankingService.addToRedis(itemId);
+
+        //then
+        verify(zSetOps).add(categoryName, itemName, 1);
+    }
+
+    @Test
+    public void testClearRedisCache() {
+        // Given
+        Set<String> categories = new HashSet<>();
+        categories.add("category1");
+        categories.add("category2");
+
+        when(redisTemplate.keys("*")).thenReturn(categories);
+
+        // When
+        redisRankingService.clearRedisCache();
+
+        // Then
+        for (String category : categories) {
+            verify(redisTemplate, times(1)).delete(category);
+        }
+    }
+}

--- a/src/test/java/com/example/Sparta_Store/rank/service/RedisRankingServiceTest.java
+++ b/src/test/java/com/example/Sparta_Store/rank/service/RedisRankingServiceTest.java
@@ -1,9 +1,9 @@
 package com.example.Sparta_Store.rank.service;
 
-import com.example.Sparta_Store.category.entity.Category;
 import com.example.Sparta_Store.ranking.RedisRankingRepository;
 import com.example.Sparta_Store.ranking.RedisRankingService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -11,9 +11,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Mockito.*;
@@ -34,6 +32,7 @@ public class RedisRankingServiceTest {
     }
 
     @Test
+    @DisplayName("아이템 레디스에 저장안된경우 생성")
     public void testAddToRedis_NewItem() {
         //given
         Long itemId = 1L;
@@ -55,6 +54,7 @@ public class RedisRankingServiceTest {
     }
 
     @Test
+    @DisplayName("레디스 캐시의 데이터값 초기화")
     public void testClearRedisCache() {
         // Given
         Set<String> categories = new HashSet<>();


### PR DESCRIPTION
방선희 튜터님께서 유저별 추천상품을 sortedSet으로 하는것은 sortedSet의 사용에 적합하지 않다고 하셔서 카테고리별 주간 조회수순 순위를 적용해보았습니다.

![image](https://github.com/user-attachments/assets/55102c71-9742-4aa6-baa2-03d51d4329e5)
1번을 상세 조회한경우 
![image](https://github.com/user-attachments/assets/366d05c3-bf4e-49fa-882a-9579c31fa568)
레디스에 값이 이렇게 저장이 됩니다.
![image](https://github.com/user-attachments/assets/9491ea9d-5fad-4339-9d89-522e357a547b)
여러번 조회시 score가 증가합니다.
![image](https://github.com/user-attachments/assets/be679306-6ed9-42ac-a7ce-4ecc3ad3e04a)
이렇게 여러개가 들어가있는경우엔
![image](https://github.com/user-attachments/assets/4ce8d0a8-aa27-43ff-a031-ae42e62e95e0)
순위대로 조회가 가능합니다
그리고 저 값은 매주 월요일에 초기화 되도록 일단 설정해두었습니다.
1분에 한번 초기화되도록 해놓고 테스트 했을때는 초기화가 잘 진행됐습니다.